### PR TITLE
Regexes in ignored_files don't work

### DIFF
--- a/src/drive_manager.rb
+++ b/src/drive_manager.rb
@@ -176,7 +176,8 @@ class DriveManager
 
   def file_ignored? path
     @config['ignored_files'].each do |ign|
-      return true if ign.match path
+      regex = Regexp.new(ign)
+      return true if regex.match path
     end
     false
   end


### PR DESCRIPTION
Hi,
First of all, thank you for this software!
Regexes in ignored_files list in config.yml didn't work, so I tried to fix the issue. They seem to work now.
Anyway I'm not a ruby programmer, so please check this commit.