### PR TITLE
Update to work with google-api-ruby-client 0.11

### DIFF
--- a/src/drive_manager.rb
+++ b/src/drive_manager.rb
@@ -49,8 +49,8 @@ class DriveManager
     @service = Google::Apis::DriveV3::DriveService.new
     @service.client_options.application_name = app_name
     @service.authorization = authorize
-    @service.request_options.open_timeout_sec = @config['timeout']
-    @service.request_options.timeout_sec = @config['timeout']
+    @service.client_options.open_timeout_sec = @config['timeout']
+    @service.client_options.read_timeout_sec = @config['timeout']
     @service.request_options.retries = @config['retries']
     @folder_cache = {}
   end


### PR DESCRIPTION
timeout_sec and open_timeout_sec moved from request_options to client_options and timeout_sec renamed to read_timeout_sec (see https://github.com/google/google-api-ruby-client/blob/master/MIGRATING.md).