### PR TITLE
Fix: Add support for refreshing expired access_token using refresh_token

### DIFF
--- a/src/drive_manager.rb
+++ b/src/drive_manager.rb
@@ -41,6 +41,11 @@ class DriveManager
       credentials = authorizer.get_and_store_credentials_from_code(
         user_id: user_id, code: code, base_url: OOB_URI)
     end
+  	# Force token refresh if expired and refresh_token is available
+  	if credentials.expired? && credentials.refresh_token
+  	  Log.log_notice "Access token expired – refreshing using refresh_token..."
+  	  credentials.fetch_access_token!
+  	end
     credentials
   end
 


### PR DESCRIPTION
This patch addresses an issue where drivesync fails silently or prompts for reauthentication after the access_token expires. The fix checks if the token is expired and, if a valid refresh_token is available, automatically refreshes the access_token via `credentials.fetch_access_token!`.

This ensures uninterrupted background syncs without manual intervention, as long as the refresh_token remains valid and stored.

Also added a log notice to confirm when token renewal is triggered.