### PR TITLE
Fix Google OAuth Flow by Updating Redirect URI and Adding 'launchy' Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'google-api-client', '0.23.4'
+gem 'launchy'

--- a/src/drive_manager.rb
+++ b/src/drive_manager.rb
@@ -41,6 +41,11 @@ class DriveManager
       credentials = authorizer.get_and_store_credentials_from_code(
         user_id: user_id, code: code, base_url: OOB_URI)
     end
+  	# Force token refresh if expired and refresh_token is available
+  	if credentials.expired? && credentials.refresh_token
+  	  Log.log_notice "Access token expired – refreshing using refresh_token..."
+  	  credentials.fetch_access_token!
+  	end
     credentials
   end
 

--- a/src/drive_manager.rb
+++ b/src/drive_manager.rb
@@ -10,7 +10,7 @@ require_relative './helper'
 include Log
 
 class DriveManager
-  OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+  OOB_URI = 'http://localhost'
   SCOPE = Google::Apis::DriveV3::AUTH_DRIVE
   CREDENTIALS_PATH = File.join(Dir.home, '.credentials',
                                "drivesync.yaml")
@@ -34,9 +34,19 @@ class DriveManager
     if credentials.nil?
       url = authorizer.get_authorization_url(
         base_url: OOB_URI)
-      puts "Open the following URL in the browser and enter the " +
-           "resulting code after authorization"
+      puts "Open the following URL in your browser:"
       puts url
+      begin
+        require 'launchy'
+        puts "Attempting to open the URL in your default browser..."
+        Launchy.open(url)
+      rescue LoadError
+        puts "Launchy gem not installed; please open the URL manually."
+      rescue StandardError => e
+        puts "Failed to open browser automatically: #{e.message}"
+        puts "Please open the URL manually."
+      end
+      print "Enter the authorization code: "
       code = STDIN.gets
       credentials = authorizer.get_and_store_credentials_from_code(
         user_id: user_id, code: code, base_url: OOB_URI)


### PR DESCRIPTION
This pull request addresses two key issues in the Google OAuth implementation:

1. **Updated Redirect URI**:  
   The deprecated `urn:ietf:wg:oauth:2.0:oob` redirect URI has been replaced with `http://localhost`, in compliance with Google’s updated OAuth policy. This ensures that users can complete the authentication flow without encountering a 400: invalid_request error when in production status.

2. **Added 'launchy' Gem**:  
   The 'launchy' gem was added to the Gemfile to support automatic opening of the OAuth URL in the user's default web browser. This improves the user experience by eliminating the need to manually copy and paste the URL.

**Note**: Even if `http://localhost` is not reachable (e.g., no local server is running), the authorization code still appears in the browser's callback URL and can be copied manually. This ensures backward compatibility with workflows that rely on manual input.

Both changes improve the out-of-box functionality of `drivesync` and restore compatibility with current Google APIs.

After merging:
- Developers should run `bundle install` to apply the gem update.
